### PR TITLE
fix: exit non-zero on partial migration and print reconciliation summary

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -31,6 +31,14 @@ class SQLiteIntegrityReport:
     skipped_foreign_key_rowids: Dict[str, List[int]] = field(default_factory=dict)
 
 
+@dataclass
+class TableMigrationResult:
+    """Per-table counters used to build the final reconciliation summary."""
+
+    source_rows: int
+    failed_inserts: int
+
+
 def classify_sqlite_foreign_key_violations(
     violations: List[Tuple[str, Optional[int], str, int]],
 ) -> Tuple[Dict[str, List[int]], List[Tuple[str, Optional[int], str, int]]]:
@@ -452,7 +460,7 @@ async def process_table(
     progress: Progress,
     batch_size: int,
     skipped_sqlite_rowids: Optional[List[int]] = None,
-) -> None:
+) -> TableMigrationResult:
     # Special handling for group table
     is_group_table = table_name.lower() == "group"
     if is_group_table:
@@ -663,10 +671,61 @@ async def process_table(
                 f"[yellow]Failed to migrate {len(failed_rows)} rows from {table_name}[/]"
             )
 
+        return TableMigrationResult(
+            source_rows=total_rows,
+            failed_inserts=len(failed_rows),
+        )
+
     except Exception as e:
         pg_cursor.connection.rollback()
         console.print(f"[bold red]Error processing table {table_name}:[/] {str(e)}")
         raise
+
+
+def print_migration_summary(
+    pg_cursor: psycopg.Cursor,
+    results: Dict[str, TableMigrationResult],
+) -> None:
+    """Reconcile SQLite vs PostgreSQL row counts and exit non-zero on partial migration."""
+    summary = Table(title="Migration Summary")
+    summary.add_column("Table", style="cyan")
+    summary.add_column("SQLite rows", justify="right")
+    summary.add_column("PostgreSQL rows", justify="right")
+    summary.add_column("Failed inserts", justify="right")
+    summary.add_column("Status")
+
+    mismatched: List[str] = []
+    for table_name, result in results.items():
+        # A failed INSERT poisons the surrounding pg transaction; roll it
+        # back so this COUNT can run without "transaction is aborted" errors.
+        pg_cursor.connection.rollback()
+        pg_cursor.execute(
+            f"SELECT COUNT(*) FROM {get_pg_safe_identifier(table_name)}"
+        )
+        pg_count = pg_cursor.fetchone()[0]
+
+        ok = pg_count == result.source_rows and result.failed_inserts == 0
+        if not ok:
+            mismatched.append(table_name)
+
+        summary.add_row(
+            table_name,
+            str(result.source_rows),
+            str(pg_count),
+            str(result.failed_inserts),
+            "[green]OK[/]" if ok else "[red]MISMATCH[/]",
+        )
+
+    console.print(summary)
+
+    if mismatched:
+        console.print(
+            f"[bold red]Migration incomplete: source and target row counts "
+            f"differ for {len(mismatched)} table(s): {', '.join(mismatched)}[/]"
+        )
+        sys.exit(1)
+
+    console.print(Panel("Migration Complete!", style="green"))
 
 
 async def migrate() -> None:
@@ -695,6 +754,7 @@ async def migrate() -> None:
         sqlite_cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
         tables = sqlite_cursor.fetchall()
 
+        results: Dict[str, TableMigrationResult] = {}
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -706,7 +766,7 @@ async def migrate() -> None:
                     if table_name in ("migratehistory", "alembic_version"):
                         continue
 
-                    await process_table(
+                    results[table_name] = await process_table(
                         table_name,
                         sqlite_cursor,
                         pg_cursor,
@@ -715,14 +775,14 @@ async def migrate() -> None:
                         integrity_report.skipped_foreign_key_rowids.get(table_name),
                     )
 
-                console.print(Panel("Migration Complete!", style="green"))
-
             except Exception as e:
                 console.print(f"[bold red]Critical error during migration:[/] {e}")
                 console.print("[red]Stack trace:[/]")
                 console.print(traceback.format_exc())
                 pg_conn.rollback()
                 sys.exit(1)
+
+        print_migration_summary(pg_cursor, results)
 
 
 def main():


### PR DESCRIPTION
## Problem

`migrate.py` exits 0 even when INSERTs into PostgreSQL fail:
`process_table()` tracks failed rows locally and prints per-row error
messages, but nothing bubbles up to the top level, which always prints
`Migration Complete!` and returns success.

This masks partial data loss. In the worst case a batch hits a
FK-violation on its first INSERT, poisons the whole pg transaction
(`current transaction is aborted, commands ignored until end of
transaction block`), and the trailing `commit()` on that aborted
transaction is effectively a rollback — so even the rows that
inserted successfully earlier in the batch are gone. The tool still
exits 0.

I hit this on a real Open WebUI migration: three tables (`chat_file`,
`knowledge_file`, `group_member`) landed with 0 rows in Postgres while
the tool reported success. Only per-table row-count reconciliation
against the source SQLite surfaced the loss.

## Change

- `process_table` now returns `TableMigrationResult(source_rows,
  failed_inserts)` instead of `None`.
- After the migration loop, for each migrated table run
  `SELECT COUNT(*)` in Postgres and compare against the source SQLite
  count. This is authoritative — the in-memory "inserted" counter can
  lie when a transaction gets aborted mid-batch (per above).
- Print a Rich summary table with columns `Table / SQLite rows /
  PostgreSQL rows / Failed inserts / Status`.
- `sys.exit(1)` if any table has a row-count mismatch or any failed
  inserts. `Panel("Migration Complete!")` prints only in the
  fully-clean case.

## Before / After

Reproduced against a local `postgres:16` container bootstrapped with
the Open WebUI schema, and a minimal SQLite (2 users, 2 chats, 1 file,
3 `chat_file` rows — one valid, two referencing deleted `file` ids and
with no FK declared in SQLite so `PRAGMA foreign_key_check` returns
clean and integrity-check passes).

**Before:**

```
Failed to migrate 2 rows from chat_file
╭─ Migration Complete! ─╮
EXIT CODE: 0
```

`SELECT COUNT(*) FROM chat_file` in Postgres → **0** (not even the
valid row survived the aborted commit).

**After:**

```
                        Migration Summary
┏━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Table     ┃ SQLite rows ┃ PostgreSQL rows ┃ Failed inserts ┃ Status   ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ user      │           2 │               2 │              0 │ OK       │
│ chat      │           2 │               2 │              0 │ OK       │
│ file      │           1 │               1 │              0 │ OK       │
│ chat_file │           3 │               0 │              2 │ MISMATCH │
└───────────┴─────────────┴─────────────────┴────────────────┴──────────┘
Migration incomplete: source and target row counts differ for 1 table(s): chat_file
EXIT CODE: 1
```

## Scope

Deliberately kept narrow — one PR, one idea:

- **Not** touching `IGNORABLE_SQLITE_FOREIGN_KEY_VIOLATIONS` or the
  FK-orphan skip logic from #24. Happy to open a follow-up
  generalizing those hardcoded pairs (my real migration had
  `chat_file→file` orphans that the current hardcoded list wouldn't
  catch).
- **Not** touching table processing order — #26 already proposes a
  fix in that area.
- **Not** changing `process_table`'s exception path: an unexpected
  exception still aborts the whole run with a stack trace, same as
  today.
