### PR TITLE
Consolidate open PRs + add JSON-numeric fix + regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# venv
+.venv/
+venv/
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+
+# Test artifacts
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# 852 MB SQLite fixture — never in git
+test_data/*.db
+test_data/*.db-shm
+test_data/*.db-wal
+
+# editor
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# secrets / logs
+.env
+*.log
+run*.log
+claude_run.*

--- a/migrate.py
+++ b/migrate.py
@@ -87,6 +87,14 @@ class SQLiteIntegrityReport:
     skipped_foreign_key_rowids: Dict[str, List[int]] = field(default_factory=dict)
 
 
+@dataclass
+class TableMigrationResult:
+    """Per-table counters used to build the final reconciliation summary."""
+
+    source_rows: int
+    failed_inserts: int
+
+
 def classify_sqlite_foreign_key_violations(
     violations: List[Tuple[str, Optional[int], str, int]],
 ) -> Tuple[Dict[str, List[int]], List[Tuple[str, Optional[int], str, int]]]:
@@ -508,7 +516,7 @@ async def process_table(
     progress: Progress,
     batch_size: int,
     skipped_sqlite_rowids: Optional[List[int]] = None,
-) -> None:
+) -> TableMigrationResult:
     # Special handling for group table
     is_group_table = table_name.lower() == "group"
     if is_group_table:
@@ -722,10 +730,60 @@ async def process_table(
                 f"[yellow]Failed to migrate {len(failed_rows)} rows from {table_name}[/]"
             )
 
+        return TableMigrationResult(
+            source_rows=total_rows,
+            failed_inserts=len(failed_rows),
+        )
     except Exception as e:
         pg_cursor.connection.rollback()
         console.print(f"[bold red]Error processing table {table_name}:[/] {str(e)}")
         raise
+
+
+def print_migration_summary(
+    pg_cursor: psycopg.Cursor,
+    results: Dict[str, TableMigrationResult],
+) -> None:
+    """Reconcile SQLite vs PostgreSQL row counts and exit non-zero on partial migration."""
+    summary = Table(title="Migration Summary")
+    summary.add_column("Table", style="cyan")
+    summary.add_column("SQLite rows", justify="right")
+    summary.add_column("PostgreSQL rows", justify="right")
+    summary.add_column("Failed inserts", justify="right")
+    summary.add_column("Status")
+
+    mismatched: List[str] = []
+    for table_name, result in results.items():
+        # A failed INSERT poisons the surrounding pg transaction; roll it
+        # back so this COUNT can run without "transaction is aborted" errors.
+        pg_cursor.connection.rollback()
+        pg_cursor.execute(
+            f"SELECT COUNT(*) FROM {get_pg_safe_identifier(table_name)}"
+        )
+        pg_count = pg_cursor.fetchone()[0]
+
+        ok = pg_count == result.source_rows and result.failed_inserts == 0
+        if not ok:
+            mismatched.append(table_name)
+
+        summary.add_row(
+            table_name,
+            str(result.source_rows),
+            str(pg_count),
+            str(result.failed_inserts),
+            "[green]OK[/]" if ok else "[red]MISMATCH[/]",
+        )
+
+    console.print(summary)
+
+    if mismatched:
+        console.print(
+            f"[bold red]Migration incomplete: source and target row counts "
+            f"differ for {len(mismatched)} table(s): {', '.join(mismatched)}[/]"
+        )
+        sys.exit(1)
+
+    console.print(Panel("Migration Complete!", style="green"))
 
 
 async def migrate() -> None:
@@ -762,6 +820,7 @@ async def migrate() -> None:
             priority = TABLE_MIGRATION_PRIORITY.get(tname, 9999)
             console.print(f"  {idx:3d}. {tname} (priority: {priority})")
 
+        results: Dict[str, TableMigrationResult] = {}
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -770,7 +829,7 @@ async def migrate() -> None:
         ) as progress:
             try:
                 for table_name in migration_order:
-                    await process_table(
+                    results[table_name] = await process_table(
                         table_name,
                         sqlite_cursor,
                         pg_cursor,
@@ -779,14 +838,14 @@ async def migrate() -> None:
                         integrity_report.skipped_foreign_key_rowids.get(table_name),
                     )
 
-                console.print(Panel("Migration Complete!", style="green"))
-
             except Exception as e:
                 console.print(f"[bold red]Critical error during migration:[/] {e}")
                 console.print("[red]Stack trace:[/]")
                 console.print(traceback.format_exc())
                 pg_conn.rollback()
                 sys.exit(1)
+
+        print_migration_summary(pg_cursor, results)
 
 
 def main():

--- a/migrate.py
+++ b/migrate.py
@@ -24,6 +24,62 @@ IGNORABLE_SQLITE_FOREIGN_KEY_VIOLATIONS = {
     ("knowledge_file", "knowledge"),
 }
 
+# Migration priority: lower number = migrated first
+# Ensures parent tables are migrated before child tables with FK references
+TABLE_MIGRATION_PRIORITY: Dict[str, int] = {
+    "auth": 10,
+    "user": 20,
+    "config": 25,
+    "model": 30,
+    "function": 35,
+    "tool": 40,
+    "prompt": 45,
+    "skill": 50,
+    "channel": 55,
+    "group": 60,
+    "chat": 70,
+    "knowledge": 75,
+    "folder": 80,
+    "file": 85,
+    "memory": 90,
+    "chatidtag": 95,
+    "tag": 96,
+    "feedback": 97,
+    "message": 98,
+    "message_reaction": 99,
+    "channel_member": 100,
+    "channel_file": 101,
+    "channel_webhook": 102,
+    "chat_file": 110,
+    "chat_message": 111,
+    "shared_chat": 112,
+    "oauth_session": 120,
+    "api_key": 125,
+    "group_member": 130,
+    "document": 140,
+    "prompt_history": 145,
+    "access_grant": 150,
+    "knowledge_directory": 155,
+    "knowledge_file": 160,
+    "automation": 170,
+    "automation_run": 175,
+    "calendar": 180,
+    "calendar_event": 185,
+    "calendar_event_attendee": 190,
+    "pinned_note": 195,
+    "note": 200,
+}
+
+
+def resolve_migration_order(
+    sqlite_tables: List[str],
+) -> List[str]:
+    """Return tables sorted by TABLE_MIGRATION_PRIORITY."""
+    return sorted(
+        [t for t in sqlite_tables if t not in ("migratehistory", "alembic_version")],
+        key=lambda t: TABLE_MIGRATION_PRIORITY.get(t, 9999),
+    )
+
 
 @dataclass
 class SQLiteIntegrityReport:
@@ -696,7 +752,15 @@ async def migrate() -> None:
         pg_cursor = pg_conn.cursor()
 
         sqlite_cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        tables = sqlite_cursor.fetchall()
+        sqlite_table_names = [row[0] for row in sqlite_cursor.fetchall()]
+
+        # Sort tables by priority to ensure FK dependencies are resolved
+        migration_order = resolve_migration_order(sqlite_table_names)
+
+        console.print("\n[cyan]Migration order (by priority):[/]")
+        for idx, tname in enumerate(migration_order, 1):
+            priority = TABLE_MIGRATION_PRIORITY.get(tname, 9999)
+            console.print(f"  {idx:3d}. {tname} (priority: {priority})")
 
         with Progress(
             SpinnerColumn(),
@@ -705,10 +769,7 @@ async def migrate() -> None:
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
         ) as progress:
             try:
-                for (table_name,) in tables:
-                    if table_name in ("migratehistory", "alembic_version"):
-                        continue
-
+                for table_name in migration_order:
                     await process_table(
                         table_name,
                         sqlite_cursor,

--- a/migrate.py
+++ b/migrate.py
@@ -465,6 +465,30 @@ def get_pg_safe_identifier(identifier: str) -> str:
     return f'"{identifier}"' if identifier.lower() in reserved_keywords else identifier
 
 
+def is_json_pg_type(pg_data_type: Optional[str]) -> bool:
+    """True when the PostgreSQL column stores JSON (config.value is ``json``,
+    group.* columns are ``jsonb``)."""
+    return (pg_data_type or "").lower() in ("json", "jsonb")
+
+
+def json_sql_literal(value: Any, pg_data_type: Optional[str] = None) -> str:
+    """Render a Python value as a safe SQL literal for a JSON/JSONB column.
+
+    SQLite gives JSON columns NUMERIC affinity, so numbers arrive here as
+    ``int``/``float`` and booleans as ``bool``.  Interpolating those into an
+    INSERT (``VALUES (..., -1, ...)``) makes the expression the wrong type
+    (``column "value" is of type json but expression is of type smallint``)
+    and the row is silently dropped.  Serialising with :func:`json.dumps`
+    preserves the JSON semantics exactly — ``json.dumps(-1)`` is still the
+    JSON number ``-1`` — and produces a string literal that casts cleanly
+    to either ``json`` or ``jsonb``.
+    """
+    encoded = json.dumps(value, ensure_ascii=False)
+    escaped = encoded.replace(chr(39), chr(39) * 2)
+    suffix = "jsonb" if (pg_data_type or "").lower() == "jsonb" else "json"
+    return f"'{escaped}'::{suffix}"
+
+
 @asynccontextmanager
 async def async_db_connections(sqlite_path: Path, pg_config: Dict[str, Any]):
     sqlite_conn = None
@@ -662,21 +686,30 @@ async def process_table(
                                 values.append("NULL")
                             elif col_type == "boolean":
                                 values.append("true" if value == 1 else "false")
-                            elif isinstance(value, str):
-                                # Check if this is a JSON column
-                                if col_type == "jsonb":
+                            elif is_json_pg_type(col_type):
+                                # JSON/JSONB column.  SQLite hands these back
+                                # as str (objects), int/float (NUMERIC affinity
+                                # scalars) or bool; every one of those shapes
+                                # is handled here so no row is silently lost.
+                                if isinstance(value, str):
                                     try:
                                         json.loads(value)
-                                        values.append(f"'{value}'::jsonb")
+                                        literal = (
+                                            f"'{value.replace(chr(39), chr(39) * 2)}'::"
+                                            f"{'jsonb' if col_type == 'jsonb' else 'json'}"
+                                        )
                                     except json.JSONDecodeError as e:
                                         console.print(
                                             f"[yellow]Warning: Invalid JSON in {col_name}: {e}[/]"
                                         )
-                                        values.append("'{}'::jsonb")
+                                        literal = "'{}'::json"
                                 else:
-                                    escaped_value = value.replace(chr(39), chr(39) * 2)
-                                    escaped_value = escaped_value.replace("\x00", "")
-                                    values.append(f"'{escaped_value}'")
+                                    literal = json_sql_literal(value, col_type)
+                                values.append(literal)
+                            elif isinstance(value, str):
+                                escaped_value = value.replace(chr(39), chr(39) * 2)
+                                escaped_value = escaped_value.replace("\x00", "")
+                                values.append(f"'{escaped_value}'")
                             else:
                                 values.append(str(value))
 

--- a/migrate.py
+++ b/migrate.py
@@ -582,6 +582,7 @@ async def process_table(
                     rows.append(tuple(cleaned_row))
 
                 for row_index, row in enumerate(rows):
+                    pg_cursor.execute("SAVEPOINT row_sp")
                     try:
                         if is_group_table:
                             console.print(
@@ -623,7 +624,9 @@ async def process_table(
                         if is_group_table:
                             console.print(f"[cyan]Executing query:[/]\n{insert_query}")
                         pg_cursor.execute(insert_query)
+                        pg_cursor.execute("RELEASE SAVEPOINT row_sp")
                     except Exception as e:
+                        pg_cursor.execute("ROLLBACK TO SAVEPOINT row_sp")
                         if is_group_table:
                             console.print(
                                 f"[red]Error processing group row {processed_rows + row_index}:[/]"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,405 @@
+"""Unit and integration tests for open-webui-postgres-migrate.
+
+Unit tests (no database required) — run with:
+    pytest tests/test_migrate.py -v
+
+PG integration tests (require `ow_fix_pg` podman container on port 54322):
+    PG_TEST_DSN=postgresql://owui:***@127.0.0.1:54322/owui \
+        pytest tests/test_migrate.py -v -k "postgres"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from typing import List, Optional, Tuple
+
+import migrate
+
+# ─────────────────────────────────────────────────────────────────────────────
+# helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+PG_TEST_DSN: Optional[str] = os.environ.get(
+    "PG_TEST_DSN", "postgresql://owui:***@127.0.0.1:54322/owui"
+)
+
+
+def _pg_conn():
+    import psycopg
+    try:
+        return psycopg.connect(PG_TEST_DSN, connect_timeout=3)
+    except Exception:
+        import pytest
+        pytest.skip("No local test PostgreSQL (set PG_TEST_DSN)")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_json_pg_type
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_is_json_pg_type_json_and_jsonb():
+    assert migrate.is_json_pg_type("json") is True
+    assert migrate.is_json_pg_type("jsonb") is True
+    assert migrate.is_json_pg_type("JSON") is True
+    assert migrate.is_json_pg_type("JSONB") is True
+
+
+def test_is_json_pg_type_rejects_other_types():
+    for t in ("integer", "text", "double precision", "uuid", "bytea", "", None):
+        assert migrate.is_json_pg_type(t) is False, f"should reject {t!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# json_sql_literal — the novel regression fix
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_json_sql_literal_negative_int_for_json():
+    """The core bug: SQLite NUMERIC affinity → Python int -1."""
+    assert migrate.json_sql_literal(-1, "json") == "'-1'::json"
+
+
+def test_json_sql_literal_negative_int_for_jsonb():
+    assert migrate.json_sql_literal(-1, "jsonb") == "'-1'::jsonb"
+
+
+def test_json_sql_literal_positive_int():
+    assert migrate.json_sql_literal(300, "json") == "'300'::json"
+
+
+def test_json_sql_literal_float():
+    assert migrate.json_sql_literal(3.14, "json") == "'3.14'::json"
+    assert migrate.json_sql_literal(-0.5, "jsonb") == "'-0.5'::jsonb"
+
+
+def test_json_sql_literal_true_false():
+    assert migrate.json_sql_literal(True, "json") == "'true'::json"
+    assert migrate.json_sql_literal(False, "jsonb") == "'false'::jsonb"
+
+
+def test_json_sql_literal_list():
+    assert migrate.json_sql_literal([1, 2, 3], "json") == "'[1, 2, 3]'::json"
+
+
+def test_json_sql_literal_nested_dict():
+    obj = {"a": 1, "b": [True, None]}
+    expected = json.dumps(obj, ensure_ascii=False)
+    lit = migrate.json_sql_literal(obj, "json")
+    assert expected in lit
+    assert lit.endswith("::json")
+
+
+def test_json_sql_literal_string_with_single_quote():
+    lit = migrate.json_sql_literal("it's here", "json")
+    # JSON encoding: "it's here"  →  '  '"it''s here"'  '::json
+    assert "''" in lit, f"single quote not doubled: {lit!r}"
+
+
+def test_json_sql_literal_unicode():
+    lit = migrate.json_sql_literal("héllo wörld", "json")
+    assert "héllo wörld" in lit
+
+
+def test_json_sql_literal_json_null():
+    assert migrate.json_sql_literal(None, "json") == "'null'::json"
+
+
+def test_json_sql_literal_default_pg_type_is_json():
+    """When pg_data_type is omitted/None the cast defaults to ::json."""
+    assert migrate.json_sql_literal(7) == "'7'::json"
+    assert migrate.json_sql_literal(7, None) == "'7'::json"
+
+
+def test_json_sql_literal_does_not_produce_bare_number():
+    """Regression: the original bug was VALUES (..., -1, ...) where -1 was a
+    bare SQL number literal, rejecting on a json column."""
+    lit = migrate.json_sql_literal(-1, "json")
+    # must be a quoted string, not a bare number
+    assert lit.startswith("'"), f"expected SQL string literal, got {lit!r}"
+    assert not lit.split("::")[0].strip().lstrip("'").isdigit() or \
+           lit.startswith("'-1'")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resolve_migration_order (Motriys98's priority map — tested via its public API)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_migration_order_parents_before_children():
+    tables = [
+        "chat_message", "chat_file", "chat",
+        "user", "auth", "config",
+        "migratehistory", "alembic_version",
+    ]
+    ordered = migrate.resolve_migration_order(tables)
+    # history tables excluded
+    assert "migratehistory" not in ordered
+    assert "alembic_version" not in ordered
+    # all other tables present exactly once
+    expected = [t for t in tables if t not in ("migratehistory", "alembic_version")]
+    assert sorted(ordered) == sorted(expected)
+    # FK chain: auth < user < chat < chat_file, chat_message
+    assert ordered.index("auth") < ordered.index("user")
+    assert ordered.index("user") < ordered.index("chat")
+    assert ordered.index("chat") < ordered.index("chat_file")
+    assert ordered.index("chat") < ordered.index("chat_message")
+
+
+def test_resolve_migration_order_unknown_table_goes_last():
+    ordered = migrate.resolve_migration_order(["user", "unknown_xyz"])
+    assert ordered[-1] == "unknown_xyz"
+
+
+def test_resolve_migration_order_all_fk_chains():
+    ordered = migrate.resolve_migration_order(list(migrate.TABLE_MIGRATION_PRIORITY.keys()))
+    chains = [
+        ("auth", "api_key"),
+        ("user", "chat"),
+        ("chat", "chat_file"),
+        ("chat", "chat_message"),
+        ("knowledge", "knowledge_file"),
+        ("message", "message_reaction"),
+        ("channel", "channel_member"),
+        ("channel", "channel_file"),
+        ("channel", "channel_webhook"),
+    ]
+    for parent, child in chains:
+        assert ordered.index(parent) < ordered.index(child), \
+            f"{parent} must come before {child}; order: {ordered}"
+
+
+def test_resolve_migration_order_empty():
+    assert migrate.resolve_migration_order([]) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# sqlite_to_pg_type
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_sqlite_to_pg_type_group_json_columns():
+    for col in ("data", "meta", "permissions", "user_ids"):
+        assert migrate.sqlite_to_pg_type("TEXT", col) == "JSONB"
+
+
+def test_sqlite_to_pg_type_basic_mappings():
+    assert migrate.sqlite_to_pg_type("INTEGER", "id") == "INTEGER"
+    assert migrate.sqlite_to_pg_type("REAL", "val") == "DOUBLE PRECISION"
+    assert migrate.sqlite_to_pg_type("TEXT", "name") == "TEXT"
+    assert migrate.sqlite_to_pg_type("BLOB", "blob") == "BYTEA"
+
+
+def test_sqlite_to_pg_type_unknown_defaults_to_text():
+    assert migrate.sqlite_to_pg_type("UNKNOWN_TYPE", "x") == "TEXT"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_pg_safe_identifier
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_get_pg_safe_identifier_reserved_words_quoted():
+    for word in ("user", "group", "order", "table", "select", "where", "from"):
+        assert migrate.get_pg_safe_identifier(word) == f'"{word}"'
+
+
+def test_get_pg_safe_identifier_non_reserved_not_quoted():
+    assert migrate.get_pg_safe_identifier("chat") == "chat"
+    assert migrate.get_pg_safe_identifier("config") == "config"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_sqlite_rowid_skip_clause
+# ─────────────────────────────────────────────────────────────────────────────
+def test_skip_clause_empty():
+    clause, params = migrate.build_sqlite_rowid_skip_clause([])
+    assert clause == ""
+    assert params == ()
+
+
+def test_skip_clause_multiple_rowids():
+    clause, params = migrate.build_sqlite_rowid_skip_clause([3, 7, 9])
+    assert "WHERE" in clause.upper()
+    assert "rowid" in clause.lower()
+    assert params == (3, 7, 9)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# classify_sqlite_foreign_key_violations
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _violations(violations: List[Tuple[str, Optional[int], str, int]]):
+    return migrate.classify_sqlite_foreign_key_violations(violations)
+
+
+def test_classify_known_orphans():
+    skipped, unknown = _violations([
+        ("chat_file", 10, "chat", 0),
+        ("knowledge_file", 5, "knowledge", 0),
+    ])
+    assert skipped == {"chat_file": [10], "knowledge_file": [5]}
+    assert unknown == []
+
+
+def test_classify_unknown_fk_left_in_unknown():
+    skipped, unknown = _violations([
+        ("user", 1, "nonexistent_parent", 0),
+    ])
+    assert skipped == {}
+    assert len(unknown) == 1
+
+
+def test_classify_none_rowid_not_skipped():
+    """A NULL rowid (FK violation without a specific ID) is not skippable."""
+    skipped, unknown = _violations([
+        ("chat_file", None, "chat", 0),
+    ])
+    assert skipped == {}
+    assert len(unknown) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TableMigrationResult
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_table_migration_result_fields():
+    r = migrate.TableMigrationResult(source_rows=409, failed_inserts=0)
+    assert r.source_rows == 409
+    assert r.failed_inserts == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PG integration tests (require ow_fix_pg running on port 54322)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_pg_savepoint_isolates_failed_row():
+    """A single failed INSERT must not poison subsequent rows (Joly0's fix)."""
+    import psycopg
+    conn = _pg_conn()
+    cur = conn.cursor()
+    try:
+        cur.execute("DROP TABLE IF EXISTS sp_test")
+        cur.execute("CREATE TABLE sp_test (id INT, val TEXT NOT NULL)")
+        conn.commit()
+
+        rows = [(1, "ok"), (2, "also_ok")]
+        cur.execute("SAVEPOINT row_sp")
+        try:
+            cur.execute("INSERT INTO sp_test (id, val) VALUES (%s, %s)", (1, None))
+            cur.execute("RELEASE SAVEPOINT row_sp")
+        except psycopg.Error:
+            cur.execute("ROLLBACK TO SAVEPOINT row_sp")
+
+        cur.execute("SAVEPOINT row_sp")
+        cur.execute("INSERT INTO sp_test (id, val) VALUES (%s, %s)", (2, "ok_after_fail"))
+        cur.execute("RELEASE SAVEPOINT row_sp")
+        conn.commit()
+
+        cur.execute("SELECT id FROM sp_test ORDER BY id")
+        assert [r[0] for r in cur.fetchall()] == [2], "row 1 should be skipped, row 2 present"
+    finally:
+        cur.execute("DROP TABLE IF EXISTS sp_test")
+        conn.commit()
+        conn.close()
+
+
+def test_pg_json_literal_inserts_numeric_into_json_column():
+    """The core JSON-numeric fix: json_sql_literal output must be accepted by
+    a PostgreSQL json column."""
+    import psycopg
+    conn = _pg_conn()
+    cur = conn.cursor()
+    try:
+        cur.execute("DROP TABLE IF EXISTS jsoncfg")
+        cur.execute("CREATE TABLE jsoncfg (key TEXT PRIMARY KEY, value JSON)")
+        conn.commit()
+
+        # int, float, bool, list — all via json_sql_literal
+        test_values: list[tuple[str, object, str]] = [
+            ("rag.top_k", 3, migrate.json_sql_literal(3, "json")),
+            ("rag.weight", 0.5, migrate.json_sql_literal(0.5, "json")),
+            ("version", -1, migrate.json_sql_literal(-1, "json")),
+            ("greeting", "hi", None),  # plain string
+            ("flag", True, migrate.json_sql_literal(True, "json")),
+            ("list", [1, 2], migrate.json_sql_literal([1, 2], "json")),
+        ]
+        for key, python_val, sql_literal in test_values:
+            if sql_literal is not None:
+                # json_sql_literal produces a SQL fragment to be interpolated
+                # into the query text (matching how the real code does it)
+                cur.execute(
+                    f"INSERT INTO jsoncfg (key, value) VALUES ('{key}', {sql_literal})"
+                )
+            else:
+                cur.execute(
+                    "INSERT INTO jsoncfg (key, value) VALUES (%s, %s::json)",
+                    (key, json.dumps(python_val)),
+                )
+        conn.commit()
+
+        cur.execute("SELECT count(*) FROM jsoncfg")
+        assert cur.fetchone()[0] == 6, "all 6 rows must be present"
+
+        # spot-check numeric values are stored as json numbers
+        cur.execute("SELECT value::text FROM jsoncfg WHERE key='rag.top_k'")
+        assert cur.fetchone()[0] == "3"
+
+        cur.execute("SELECT value::text FROM jsoncfg WHERE key='version'")
+        assert cur.fetchone()[0] == "-1"
+    finally:
+        cur.execute("DROP TABLE IF EXISTS jsoncfg")
+        conn.commit()
+        conn.close()
+
+
+def test_pg_savepoint_and_sql_literal_combined():
+    """Integration of Joly0's savepoint + our json_sql_literal in one pattern.
+
+    Uses the same raw-SQL savepoint pattern as migrate.py (not a context
+    manager) to mirror the production code path.
+    """
+    import psycopg
+    conn = _pg_conn()
+    cur = conn.cursor()
+    try:
+        conn.rollback()
+        cur.execute("DROP TABLE IF EXISTS combined")
+        cur.execute("CREATE TABLE combined (key TEXT PRIMARY KEY, val JSON)")
+        conn.commit()
+
+        # row 1: valid json, goes in (string-interpolated SQL, same as migrate.py)
+        lit1 = migrate.json_sql_literal({"a": 1}, "json")
+        cur.execute(f"SAVEPOINT row_sp")
+        cur.execute(f"INSERT INTO combined (key, val) VALUES ('k1', {lit1})")
+        cur.execute(f"RELEASE SAVEPOINT row_sp")
+
+        # row 2: duplicate key → fails; savepoint recovers
+        lit2 = migrate.json_sql_literal({"b": 2}, "json")
+        cur.execute("SAVEPOINT row_sp")
+        try:
+            cur.execute(f"INSERT INTO combined (key, val) VALUES ('k1', {lit2})")
+            cur.execute("RELEASE SAVEPOINT row_sp")
+        except psycopg.Error:
+            cur.execute("ROLLBACK TO SAVEPOINT row_sp")
+
+        # row 3: valid, goes in despite row 2 failing
+        lit3 = migrate.json_sql_literal(42, "json")
+        cur.execute("SAVEPOINT row_sp")
+        cur.execute(f"INSERT INTO combined (key, val) VALUES ('k2', {lit3})")
+        cur.execute("RELEASE SAVEPOINT row_sp")
+        conn.commit()
+
+        cur.execute("SELECT key, val::text FROM combined ORDER BY key")
+        rows = dict(cur.fetchall())
+        assert set(rows.keys()) == {"k1", "k2"}, f"got keys: {list(rows.keys())}"
+        assert rows["k1"] == '{"a": 1}', f"k1 val: {rows['k1']!r}"
+        assert rows["k2"] == "42", f"k2 val: {rows['k2']!r}"
+    finally:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        try:
+            cur.execute("DROP TABLE IF EXISTS combined")
+            conn.commit()
+        except Exception:
+            pass
+        conn.close()


### PR DESCRIPTION
## Summary

This branch bundles four independent, previously-unmerged fixes against `main`
(v1.0.7).  Each is a small, self-contained commit so the maintainer can pick
any subset.  The first three are lifted verbatim from PRs that are already
open or closed in this repo; this PR is their consolidation plus one net-new
bug fix and a regression test suite.

### Per-commit credit

| commit | author | upstream PR | what it fixes |
|---|---|---|---|
| `785b525` | **Joly0** | #25 (closed) | **Per-row savepoint** — a single failed INSERT no longer poisons the rest of the batch (`InFailedSqlTransaction` recovery). |
| `e82a16b` | **Motriys98-alt** | #26 (open) | **FK-aware table ordering** — parents load before children via a `TABLE_MIGRATION_PRIORITY` map. Fixes the FK-violation aborts in issue #20 / #22 / #23. |
| `83ad684` | **FedorenkoKirill** | #27 (open) | **Verification pass + non-zero exit** — after each table the source and target row counts are reconciled; any mismatch sets the process exit code to 1. No more green "Migration Complete!" on a partial migration. |
| `f0e7a88` | **Cuppett** | (new) | **JSON-typed SQLite numeric values** — SQLite gives JSON columns NUMERIC affinity, so a `config.value` row holding `-1` comes back as Python `int(-1)`, is interpolated as `VALUES (..., -1, ...)`, and PostgreSQL rejects it with `column "value" is of type json but expression is of type smallint`. The row is silently dropped — 30 rows in the 852 MB fixture I tested against. `json_sql_literal()` + `is_json_pg_type()` handle every case (`int`, `float`, `bool`, `list`, `dict`, `unicode`, nested). |
| `4437703` | **Cuppett** | (new) | **Regression test suite** (32 tests: 29 unit, 3 PG integration) + `.gitignore`. |

### Why this instead of merging #25/#26/#27 individually

- **PR #25** is **closed unmerged** — its savepoint fix never landed in `main`. The same 3-line change is at `785b525` here with Joly0 credited as author.
- **PRs #26 and #27 are both open** and both touch `migrate.py` in the same region (the `async def migrate()` loop), so merging them sequentially would force a small conflict on whoever lands second. This PR folds both in with their original authorship preserved (`e82a16b` = Motriys98-alt, `83ad684` = FedorenkoKirill).
- **None of the three ships tests**, which is exactly how the JSON-numeric data-loss bug slips through on every one of them. This PR adds the regression suite and a `.gitignore` covering the fixture / venv / logs.
- **Commit-level attribution is preserved** (`git log` shows Joly0, Motriys98-alt and FedorenkoKirill by name on their own commits), so the maintainer can merge this PR as-is, or pick any subset by `git cherry-pick`, or ignore this PR and merge #26 and #27 directly.

### Verification (run against the real fixture)

Fixture: 852 MB `webui.db` from an OpenWebui 0.8.12 production instance
(162 chats, 1100 messages, 5 users, 409 config rows, 2 orphan `chat_file`
rows).

Against `main` before these commits, `migrate.py` on this fixture produces:

```
Failed to migrate 30 rows from config
   (all numeric-typed: version, rag.top_k, rag.chunk_size,
    image_generation.steps, memories.user_char_limit, ...)
Migration Complete!   ← green panel, silent data loss
```

With all 5 commits applied:

```
| config       | 409 | 409 | 0 | OK |
| chat_message | 1100 | 1100 | 0 | OK |
| … all 43 tables … |
Migration Complete!   ← exit code 0
```

All **32/32** tests pass, including 3 live Postgres integration tests:
- `test_pg_savepoint_isolates_failed_row` (Joly0's savepoint, real PG)
- `test_pg_json_literal_inserts_numeric_into_json_column` (our JSON fix vs. `PG json` column)
- `test_pg_savepoint_and_sql_literal_combined` (both together, in the exact raw-SQL pattern `migrate.py` uses)

### Related

- Fixes #20 (FK ordering + `InFailedSqlTransaction` poison) — Joly0 + Motriys98 commits
- Fixes #22 (orphan `chat_file`/`knowledge_file` abort) — ordering ensures the parent chat loads before its orphaned children; #24's skip logic still protects against truly orphaned rows
- Fixes #23 (v0.8.12 `knowledge_file` abort + batch poison) — ordering + savepoint
- **Replaces #25** (closed unmerged) — savepoint fix is present at `785b525` with Joly0 credited
- **Suggested replacement for #26** (Motriys98) — `TABLE_MIGRATION_PRIORITY` map and `resolve_migration_order` are used verbatim at `e82a16b`; Motriys98-alt is credited as the author of that commit
- **Suggested replacement for #27** (FedorenkoKirill) — `TableMigrationResult` / `print_migration_summary` are used verbatim at `83ad684`; FedorenkoKirill is credited
- Does **not** attempt #17 (auto-sequence / `setval`): every OpenWebui `id` column in the target schema is `text`/`uuid`/`varchar`; the only integer-PK + sequence is `config_old`, and #24 already migrates that row whole.

### Author credit

- **Joly0** — `785b525` "Add per-row savepoints to isolate failed INSERTs" (from #25, credit to PR #25)
- **Motriys98-alt** — `e82a16b` "Migrate tables in FK-dependency order (priority map)" (from #26, credit to PR #26)
- **FedorenkoKirill** — `83ad684` "exit non-zero on partial migration; print reconciliation summary" (from #27, credit to PR #27)
- **Cuppett** — `f0e7a88` + `4437703` (JSON-numeric fix + regression test suite)
